### PR TITLE
The Onoros Expansion 1.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3072,3 +3072,113 @@ The soft buzz of the speaker box sounded again.
 
 "Bud," the creature's small voice chimed out.  
 "Your Father… wasn't he a master cloner? He would have had hundreds of heads at one time."
+
+
+# The Onoros Expansion 1
+
+The skies over the planet Eyeke were a perpetual shade of dusk, an amalgamation of toxic gases and atmospheric particulates that blocked out the sun's light. 
+The Khaureds, ever-expanding in their quest for resources, had seen potential in Eyeke where others saw only desolation. This barren world was rich with Trilium veins buried deep beneath its surface, a rare element that fueled not only Khaured technology but also their ever-growing influence across the Federation.
+
+To unlock this wealth, the Khaureds turned to their most reliable allies: the Onoros. An alliance that had begun as a mere convenience had, over the decades, grown into a symbiotic relationship, at least on the surface. For the Khaureds, the Onoros Drones were the perfect workforce: tireless, compliant, and endlessly adaptable. The Directors ensured operations ran smoothly, and the new Diplomats kept the peace and prevented disagreements among the representatives in the Congress.
+
+Today, as the sun dipped below the horizon, casting long shadows over the mining camp, an Onoros Director named Venx stood at the edge of a vast Trilium mine. Venx was a typical Director, a few inches taller than the average Drone, with an air of authority that came not from physical strength but from the hive mind's knowledge and strategic oversight. Venx's round, noseless face and large, dark eyes betrayed no emotion, but beneath the surface, a web of telepathic communication connected him to the hundreds of Drones laboring below.
+
+A Khaured overseer approached, silhouetted against the dim glow of the mining camp's artificial lights. His name was Pavok, a grizzled veteran who had supervised countless mining operations across the galaxy.
+
+"Venx," Pavok said, his voice a harsh rasp. "The Trilium yields are impressive, but there's been chatter. Some of your Drones have been behaving... oddly."
+
+Venx's expression remained placid. "Oddly, Overseer?"
+
+Pavok's eyes narrowed. "Yes. Movements that don't match the tasks assigned. Digging in places not marked for excavation. It's subtle, but I've seen it."
+
+Venx paused for a moment as he relayed this concern to the hive mind. A brief pulse of reassurance came back from the Maxa. "The Drones are efficient, Overseer. They sense the richest veins of Trilium. If they are digging in unexpected areas, it is because they have detected something of value."
+
+Pavok's third eye twitched, a sure sign of his suspicion. "You're certain of that, are you? The Khaureds have worked with your people long enough to know that there's more to the Onoros than what we see on the surface."
+
+Venx met his gaze, unblinking. "We serve the Khaureds loyally, as always."
+
+Pavok grunted, his eyes flitting back to the massive excavation. "See that it stays that way, Director. If there's any deviation from protocol, I'll report it to the Council. Remember, the Khaureds may need your labor, but your kind are not irreplaceable."
+
+Venx gave a small, almost imperceptible nod, then returned his attention to the Drones. Beneath his calm exterior, he could feel the quiet hum of the Maxa's will guiding his every action.
+
+As Venx surveyed the camp, a new transmission rippled through the hive mind. The Maxa was speaking, not to him directly, but to the entire Onoros race. It was a feeling more than words, a sense of anticipation, of something on the horizon. The message was clear: the time for subtlety was coming to an end.
+
+Meanwhile, on Alta, the Federation Congress was in session. The grand chamber was filled with representatives from dozens of races. Among them, the Onoros Diplomat known as Zaren sat in silence, observing the proceedings with unblinking eyes. Zaren, like all Onoros, was connected to the hive mind, his thoughts and actions guided by the Maxa.
+
+The Onoros had been brought into the Federation Congress to suppress suspicions about their alliance with the Khaureds, but Zaren knew that his presence here was more than just a political maneuver. The Maxa had a purpose for everything, and Thanos role was to listen, to learn, and to subtly influence. The Khaureds may have thought they controlled the Onoros, but Zaren knew better. The Maxa's will was the true power behind their actions. 
+
+Today's session was focused on the growing influence of the Khaureds within the Federation. There were whispers of monopolistic practices, of exploitation, and of a race that seemed to be spreading its reach too far, too fast. The Khaured representative, a cold-eyed politician named Xaza, stood at the center of the chamber, defending his people's actions with carefully crafted rhetoric.
+
+The Khaured representative, Xaza, a cold-eyed politician, was engaged in a tense debate with a Murien delegate  named Lirien, an amphibian whose bulbous eyes glistened with skepticism.
+
+"And what of the Onoros?" Lirien croaked, his voice echoing across the chamber. "They seem to be everywhere your people go, yet they have no voice of their own. Are they not capable of speaking for themselves, or is it that you speak for them?"
+
+Xaza shot a glance at Zaren, a subtle signal. The Onoros diplomat rose slowly from his seat, every movement measured, deliberate.
+
+“We, the Onoros, are a unified people,” Zaren said, his voice calm and melodious. “Our alliance with the Khaureds is based on mutual benefit and shared goals. We do not seek power or influence; our purpose is to work, to contribute, and to ensure that the Federation thrives. The Maxa, our guiding force, has chosen this path for us, and we follow it willingly.”
+
+Lirien's eyes narrowed. "Curious that a species so embedded in every corner of the Federation claims to seek no influence. One might think that a race with such reach would have a broader agenda."
+
+Zaren's expression remained neutral. "Our purpose is simple, to serve and to ensure the success of our alliances. Nothing more."
+
+Lirien wasn't convinced, and whispers echoed through the chamber as the tension thickened.
+
+The words were true enough, but Zaren could sense the undercurrents of doubt that flowed through the minds of the other delegates. They were wary of the Onoros, of the unknown, and the Maxa's presence loomed large in their thoughts. 
+
+Back on Eyeke, Venx oversaw the night's work with a growing sense of purpose. The Drones were moving with newfound urgency, their exosuits whirring as they dug deeper into the earth. Then, Venx felt a ripple through the hive mind, a message from the Maxa.
+
+It was during these quiet moments that Venx felt the hive mind most acutely. The thoughts of hundreds of Drones flowed through him, a river of shared consciousness that pulsed with life and purpose. But tonight, there was something different, a new directive, subtle yet insistent, that came directly from the Maxa.
+
+The Drones began to move in unison, their actions shifting from the methodical extraction of Trilium to something more deliberate. Venx could feel the change, though he did not fully understand it. The Maxa was guiding them, their movements precise and purposeful, but the reasoning behind this new directive was beyond his comprehension. 
+
+As the hours passed, the Drones continued their work, but now their efforts were focused on something hidden deep within the earth. The tunnel they were digging was no longer just a mining shaft, it was becoming something else, something that the Khaureds had not authorized. Venx felt a flicker of unease, a rare emotion for an Onoros, but the hive mind drowned it out with its collective will.
+
+“Director Venx,” came a voice from behind him. It was Pavok again, his tone suspicious. “Why have your Drones deviated from the main excavation site? They're digging where they've no business digging.”
+
+Venx turned slowly to face him. “The Maxa has detected something important. The Drones are following its guidance.”
+
+Pavok's third eye flicked toward the deepening tunnel. “I wasn't informed of any changes. The Khaureds give the orders here, Venx. Not your Maxa.”
+
+“The Maxa's guidance cannot be ignored,” Venx replied, his voice calm yet firm.
+
+Pavok took a step closer, his face tightening with annoyance. “I don't care what your Maxa thinks it's found. You answer to me. Call off your Drones, now.”
+
+Venx's mind pulsed with the Maxa's influence, and for the first time, he found himself resisting the Khaured's demands. “The Maxa does not take orders from the Khaureds.”
+
+It was already dawn, the Drones had uncovered a massive subterranean chamber, its walls lined with veins of glowing Trilium. But it was not the Trilium that had drawn them here, it was something else, something ancient and powerful that pulsed with energy at the chamber's center. 
+
+The object was unlike anything Venx had ever seen. It was a monolithic structure, smooth and black, with strange symbols etched into its surface. The Maxa's influence was strong here, its presence almost tangible in the air. The Drones gathered around the monolith, their exosuits casting long shadows in the dim light, as if they were paying homage to it.
+
+Pavok's eyes widened as the monolith began to hum with energy. “What… what is this?” he whispered, his earlier bravado fading.
+
+Venx's gaze remained fixed on the monolith. “It is the future,” he said softly, his voice filled with a quiet certainty. “The Maxa's plan is unfolding.”
+
+Venx could feel the Maxa's will merging around the object, a sense of purpose that transcended anything he had experienced before. The hive mind was focused, intent, and for the first time, Venx felt a hint of something deeper, something that had been hidden from him and the other Onoros for as long as he could remember. 
+
+The monolith was a conduit, a key to something far greater than the Drones, the Directors, or even the Khaureds. It was a link to the Maxa, a direct connection to the being that guided the Onoros. And as Venx stood before it, he realized that the Maxa's plans were far more complex than he had ever imagined.
+
+As the chamber filled with light, Pavok staggered back, his three eyes were widened in fear. “What have you done, Venx? What have you unleashed?”
+
+Venx turned to him, his eyes glowing with the same light that radiated from the monolith. “The time for subtlety is over, Overseer. The Onoros will no longer serve the Khaureds. We have a higher calling.”
+
+“You… you've doomed us all…” Pavok stammered, backing away.
+
+Venx watched him with serene detachment. “No, Overseer. The galaxy will soon be reshaped. The Onoros are merely stepping into their rightful place.”
+
+As Pavok fled, Venx turned back to the monolith, the Maxa's will now fully intertwined with his own. The Onoros were no longer tools of the Khaureds, They were part of a grander design, one that had been set in motion long before the Khaureds had discovered Eyeke, and perhaps even before the Onoros had come into the Federation's awareness. 
+
+The Maxa had a purpose beyond mere survival or alliance-building, it was orchestrating a transformation, one that would alter the balance of power in the galaxy. Venx's mind, usually focused on the task at hand, now swam with thoughts and images that were not his own. The Maxa was communicating something profound, something that transcended the ordinary directives that flowed through the hive mind. It was as if the Maxa was showing him a glimpse of the future, a future where the Onoros were no longer just a workforce, but a force of their own. The Drones, still gathered around the monolith, began to move again, but this time their actions were more deliberate, more ritualistic. 
+
+They started to place pieces of the mined Trilium into slots at the base of the monolith, as if they were unlocking something. The Trilium, which had always been a source of power and wealth, was now a key to awakening whatever lay dormant within the monolith. As the last piece of Trilium was slotted into place, the monolith began to hum with energy. The strange symbols etched into its surface glowed with a myterious light, and the chamber was filled with a low, resonant tone that seemed to vibrate through the very bones of those present. Venx could feel the hive mind's collective anticipation, a tension that had been building for a long time, now on the verge of release. Suddenly, the monolith activated. Beams of light shot out from its surface, connecting with the Drones, their exosuits, and Venx himself. 
+
+The light was not blinding but enveloping, wrapping them in a warm, pulsating glow. Venx felt his consciousness expand, his mind no longer bound by the limitations of his physical form. He was connected directly to the Maxa in a way he had never been before, as if the distance between them had collapsed, and they were now one. The Maxa's presence flooded his mind, not as a controlling force, but as a guiding one. Venx saw visions of the Onoros's true purpose of their destiny beyond serving the Khaureds. The Onoros were the chosen stewards of the galaxy's hidden powers, the keepers of ancient technologies that predated even the oldest civilizations in the Federation. 
+
+The monolith was but one of many, scattered across the stars, each waiting for the right moment to be awakened. Venx understood now that the Khaureds were merely a stepping stone, a means to an end. The alliance had given the Onoros access to the resources and technology they needed, but it was never meant to last. The Khaureds, with their greed and shortsightedness, had unwittingly paved the way for the Onoros's rise. The Maxa had used them to gather strength, to spread the Onoros across the galaxy, embedding them in the infrastructure of countless worlds. But now, the time for subtlety was over. The monolith was a signal, a beacon that would activate the other ancient structures hidden on worlds throughout the Federation. Each would awaken the latent power within the Trilium veins, linking together to form a network of unimaginable energy and influence. The Onoros, guided by the Maxa, would control this network, shaping the future of the galaxy. 
+
+The Khaureds, and indeed the rest of the Federation, would not see it coming. They had grown complacent, believing that they were the dominant force in the galaxy. But the Maxa had planned for this moment, waiting for the right time to reveal its hand. The Onoros, once seen as mere tools, would soon be recognized as the true power behind the scenes. As the light from the monolith intensified, Venx felt a surge of power flow through him. The hive mind was stronger than ever, its reach extending beyond Eyeke, beyond the Federation, to the farthest corners of the galaxy. The Onoros were awakening, and with them, the ancient forces that the Maxa had kept hidden for so long. 
+
+The Onoros knew about the take over, They could feel it in their very being, a sense of purpose that had eluded them for centuries. They were no longer just servants, they were the forerunners of a new era. As the light from the monolith finally dimmed, Venx felt the connection with the Maxa solidify. He was no longer just a Director overseeing the work of Drones, he was a conduit of the Maxa's will, a leader in the silent expansion that was now fully underway. 
+
+The Drones, still in their exosuits, turned as one to face Venx, their eyes glowing with the same light that had emanated from the monolith. Venx raised his hand, and the Drones responded in kind, their movements synchronized as if they were all part of the same body. The time had come to fulfill the Maxa's plan, to take the next step in the Onoros's evolution. The galaxy would soon learn the true nature of the Onoros, and by then, it would be too late to stop them. The silent expansion was over. The Onoros were ready to claim their place in the galaxy not as servants, but as rulers. And under the guidance of the Maxa, they would reshape the galaxy in their image, ensuring that the Onoros would endure for millennia to come.   
+
+

--- a/README.md
+++ b/README.md
@@ -3075,7 +3075,6 @@ The soft buzz of the speaker box sounded again.
 
 
 # The Onoros Expansion 1
-
 The skies over the planet Eyeke were a perpetual shade of dusk, an amalgamation of toxic gases and atmospheric particulates that blocked out the sun's light. 
 The Khaureds, ever-expanding in their quest for resources, had seen potential in Eyeke where others saw only desolation. This barren world was rich with Trilium veins buried deep beneath its surface, a rare element that fueled not only Khaured technology but also their ever-growing influence across the Federation.
 
@@ -3115,7 +3114,7 @@ The Khaured representative, Xaza, a cold-eyed politician, was engaged in a tense
 
 Xaza shot a glance at Zaren, a subtle signal. The Onoros diplomat rose slowly from his seat, every movement measured, deliberate.
 
-“We, the Onoros, are a unified people,” Zaren said, his voice calm and melodious. “Our alliance with the Khaureds is based on mutual benefit and shared goals. We do not seek power or influence; our purpose is to work, to contribute, and to ensure that the Federation thrives. The Maxa, our guiding force, has chosen this path for us, and we follow it willingly.”
+"We, the Onoros, are a unified people," Zaren said, his voice calm and melodious. "Our alliance with the Khaureds is based on mutual benefit and shared goals. We do not seek power or influence; our purpose is to work, to contribute, and to ensure that the Federation thrives. The Maxa, our guiding force, has chosen this path for us, and we follow it willingly."
 
 Lirien's eyes narrowed. "Curious that a species so embedded in every corner of the Federation claims to seek no influence. One might think that a race with such reach would have a broader agenda."
 
@@ -3133,25 +3132,25 @@ The Drones began to move in unison, their actions shifting from the methodical e
 
 As the hours passed, the Drones continued their work, but now their efforts were focused on something hidden deep within the earth. The tunnel they were digging was no longer just a mining shaft, it was becoming something else, something that the Khaureds had not authorized. Venx felt a flicker of unease, a rare emotion for an Onoros, but the hive mind drowned it out with its collective will.
 
-“Director Venx,” came a voice from behind him. It was Pavok again, his tone suspicious. “Why have your Drones deviated from the main excavation site? They're digging where they've no business digging.”
+"Director Venx," came a voice from behind him. It was Pavok again, his tone suspicious. "Why have your Drones deviated from the main excavation site? They're digging where they've no business digging."
 
-Venx turned slowly to face him. “The Maxa has detected something important. The Drones are following its guidance.”
+Venx turned slowly to face him. "The Maxa has detected something important. The Drones are following its guidance."
 
-Pavok's third eye flicked toward the deepening tunnel. “I wasn't informed of any changes. The Khaureds give the orders here, Venx. Not your Maxa.”
+Pavok's third eye flicked toward the deepening tunnel. "I wasn't informed of any changes. The Khaureds give the orders here, Venx. Not your Maxa."
 
-“The Maxa's guidance cannot be ignored,” Venx replied, his voice calm yet firm.
+"The Maxa's guidance cannot be ignored," Venx replied, his voice calm yet firm.
 
-Pavok took a step closer, his face tightening with annoyance. “I don't care what your Maxa thinks it's found. You answer to me. Call off your Drones, now.”
+Pavok took a step closer, his face tightening with annoyance. "I don't care what your Maxa thinks it's found. You answer to me. Call off your Drones, now."
 
-Venx's mind pulsed with the Maxa's influence, and for the first time, he found himself resisting the Khaured's demands. “The Maxa does not take orders from the Khaureds.”
+Venx's mind pulsed with the Maxa's influence, and for the first time, he found himself resisting the Khaured's demands. "The Maxa does not take orders from the Khaureds."
 
 It was already dawn, the Drones had uncovered a massive subterranean chamber, its walls lined with veins of glowing Trilium. But it was not the Trilium that had drawn them here, it was something else, something ancient and powerful that pulsed with energy at the chamber's center. 
 
 The object was unlike anything Venx had ever seen. It was a monolithic structure, smooth and black, with strange symbols etched into its surface. The Maxa's influence was strong here, its presence almost tangible in the air. The Drones gathered around the monolith, their exosuits casting long shadows in the dim light, as if they were paying homage to it.
 
-Pavok's eyes widened as the monolith began to hum with energy. “What… what is this?” he whispered, his earlier bravado fading.
+Pavok's eyes widened as the monolith began to hum with energy. "What… what is this?" he whispered, his earlier bravado fading.
 
-Venx's gaze remained fixed on the monolith. “It is the future,” he said softly, his voice filled with a quiet certainty. “The Maxa's plan is unfolding.”
+Venx's gaze remained fixed on the monolith. “It is the future," he said softly, his voice filled with a quiet certainty. “The Maxa's plan is unfolding."
 
 Venx could feel the Maxa's will merging around the object, a sense of purpose that transcended anything he had experienced before. The hive mind was focused, intent, and for the first time, Venx felt a hint of something deeper, something that had been hidden from him and the other Onoros for as long as he could remember. 
 
@@ -3159,11 +3158,11 @@ The monolith was a conduit, a key to something far greater than the Drones, the 
 
 As the chamber filled with light, Pavok staggered back, his three eyes were widened in fear. “What have you done, Venx? What have you unleashed?”
 
-Venx turned to him, his eyes glowing with the same light that radiated from the monolith. “The time for subtlety is over, Overseer. The Onoros will no longer serve the Khaureds. We have a higher calling.”
+Venx turned to him, his eyes glowing with the same light that radiated from the monolith. "The time for subtlety is over, Overseer. The Onoros will no longer serve the Khaureds. We have a higher calling."
 
 “You… you've doomed us all…” Pavok stammered, backing away.
 
-Venx watched him with serene detachment. “No, Overseer. The galaxy will soon be reshaped. The Onoros are merely stepping into their rightful place.”
+Venx watched him with serene detachment. "No, Overseer. The galaxy will soon be reshaped. The Onoros are merely stepping into their rightful place."
 
 As Pavok fled, Venx turned back to the monolith, the Maxa's will now fully intertwined with his own. The Onoros were no longer tools of the Khaureds, They were part of a grander design, one that had been set in motion long before the Khaureds had discovered Eyeke, and perhaps even before the Onoros had come into the Federation's awareness. 
 


### PR DESCRIPTION
In "The Onoros Expansion 1," the Khaureds mine Trilium on the desolate planet Eyeke, using the hive-mind Onoros as their workforce under Director Venx’s oversight. Suspicion arises when the Onoros Drones dig in unauthorized areas, guided by the Maxa, their enigmatic leader. In the Federation Congress, Onoros Diplomat Zaren downplays their Khaured alliance, masking the Maxa’s broader intentions. On Eyeke, the Drones uncover and activate an ancient monolith with Trilium, connecting Venx and the Onoros to the Maxa, who reveals their destiny: to control a network of monoliths and dominate the galaxy. As the Khaured overseer Pavok flees, Venx accepts this shift, signaling the Onoros’s rise from servants to rulers under the Maxa’s guidance.